### PR TITLE
時刻変換をテストしやすいようにし、コードの重複をなくしました。

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  # 秒数を人間が読める形式に変換する
+  def sec2h(t)
+    if t < 60
+      time = "#{t}秒"
+    end
+    if t/60 != 0
+      time = "#{(t/60)}分"
+    end
+    if t/3600 != 0
+      time = "#{(t/3600)}時間#{(t/60 - (t/3600)*60)}分"
+    end
+
+    time
+  end
 end

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -23,27 +23,11 @@
       <meta neme="refresh" content="10">
       <% num=1 %>
       <% @rank.each do |ranking| %>
-        <!-- 更新時間を計算 -->
-        <% t = (Time.zone.now - ranking.updated_at).to_i %>
-        <% time = nil %>
-
-        <% if t<60 then %>
-          <% time = t.to_s + "秒前" %>
-        <% end %>
-
-        <% if t/60 != 0 then %>
-          <% time = (t/60).to_s + "分前"  %>
-        <% end %>
-    
-        <% if t/3600 != 0 then %>
-          <% time = (t/3600).to_s + "時間" + (t/60 - (t/3600)*60).to_s + "分前" %>
-        <% end %>
-
         <tr>
           <td><h1><%= num  %>位</h1></td>
           <td><h1><%= ranking.name %></h1></td>
           <td><h1><%= ranking.seats_occ %>％</h1></td>
-          <td><h1><%= time %></h1></td>
+          <td><h1><%= sec2h((Time.zone.now - ranking.updated_at).to_i) %>前</h1></td>
         </tr>
 
         <% num = num+1 %>

--- a/app/views/restaurants/search.html.erb
+++ b/app/views/restaurants/search.html.erb
@@ -20,26 +20,10 @@
       </tr>
 
       <% @searched.each do |ranking| %>
-
-        <!-- 更新時間を計算 -->
-        <% t = (Time.zone.now - ranking.updated_at).to_i %>
-        <% time = nil %>
-
-        <% if t<60 then %>
-          <% time = t.to_s + "秒前" %>
-        <% end %>
-
-        <% if t/60 != 0 then %>
-          <% time = (t/60).to_s + "分前"  %>
-        <% end %>
-
-        <% if t/3600 != 0 then %>
-          <% time = (t/3600).to_s + "時間" + (t/60 - (t/3600)*60).to_s + "分前" %>
-        <% end %>
         <tr>
           <td><h1><%= ranking.name %></h1></td>
           <td><h1><%= ranking.seats_occ %>％</h1></td>
-          <td><h1><%= time %></h1></td>
+          <td><h1><%= sec2h((Time.zone.now - ranking.updated_at).to_i) %>前</h1></td>
         </tr>
       <% end %>
     </table>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -16,6 +16,6 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "1時間", sec2h(3600)
   end
   test "1時間より長い変換" do
-    assert_equal "1時間10分", sec2h(3700)
+    assert_equal "1時間1分40秒", sec2h(3700)
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -10,12 +10,12 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "1分", sec2h(60)
   end
   test "1分より長くて1時間未満の変換" do
-    assert_equal "1分8秒", sec2h(68)
+    assert_equal "1分", sec2h(68)
   end
   test "1時間の変換" do
-    assert_equal "1時間", sec2h(3600)
+    assert_equal "1時間0分", sec2h(3600)
   end
   test "1時間より長い変換" do
-    assert_equal "1時間1分40秒", sec2h(3700)
+    assert_equal "1時間1分", sec2h(3700)
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "1分未満の変換" do
+    assert_equal "1秒", sec2h(1)
+  end
+  test "1分の変換" do
+    assert_equal "1分", sec2h(60)
+  end
+  test "1分より長くて1時間未満の変換" do
+    assert_equal "1分8秒", sec2h(68)
+  end
+  test "1時間の変換" do
+    assert_equal "1時間", sec2h(3600)
+  end
+  test "1時間より長い変換" do
+    assert_equal "1時間10分", sec2h(3700)
+  end
+end


### PR DESCRIPTION
秒数を切り捨てる仕様だと思いますが、ちょっと自信がないです。何かあったらコメントで教えてください。

このヘルパーを使って、ビューで`<%= sec2h(3700) %>`のような書き方をすると、`1時間1分`のように置き換わります。重複コードがなくなるので、修正時に修正漏れがなくなって便利だと思います。