### PR TITLE
検索にて、%、_、\をそのままの意味で検索が出来るようにしました。

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -18,7 +18,7 @@ class RestaurantsController < ApplicationController
   end
 
   def search
-    escaped = params[:name].gsub('%', '\%').gsub('_', '\_')
+    escaped = params[:name].gsub('\\', '\\\\\\\\').gsub('%', '\%').gsub('_', '\_')
     @searched = Restaurant.where("name like '%" + escaped + "%'" + "or hurigana like '%" + escaped + "%'")
     if @searched.empty?
       @error = "検索ワードがヒットしませんでした。もう一度入れなおして下さい。"

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -19,7 +19,7 @@ class RestaurantsController < ApplicationController
 
   def search
     escaped = params[:name].gsub('\\', '\\\\\\\\').gsub('%', '\%').gsub('_', '\_')
-    @searched = Restaurant.where("name like '%" + escaped + "%'" + "or hurigana like '%" + escaped + "%'")
+    @searched = Restaurant.where("name like ? or hurigana like ?", "%#{escaped}%", "%#{escaped}%")
     if @searched.empty?
       @error = "検索ワードがヒットしませんでした。もう一度入れなおして下さい。"
     end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -18,7 +18,8 @@ class RestaurantsController < ApplicationController
   end
 
   def search
-    @searched = Restaurant.where("name like '%" + params[:name] + "%'" + "or hurigana like '%" + params[:name] + "%'")
+    escaped = params[:name].gsub('%', '\%').gsub('_', '\_')
+    @searched = Restaurant.where("name like '%" + escaped + "%'" + "or hurigana like '%" + escaped + "%'")
     if @searched.empty?
       @error = "検索ワードがヒットしませんでした。もう一度入れなおして下さい。"
     end

--- a/test/controllers/restaurants_controller_test.rb
+++ b/test/controllers/restaurants_controller_test.rb
@@ -16,5 +16,17 @@ class RestaurantsControllerTest < ActionController::TestCase
       shop_names_in_view.include?(/^.*#{shop}.*$/)
     end
   end
+
+  test "検索で%を特別扱いしない" do
+    post :search, name: '%'
+    assert_response :success
+    assert_equal 1, assigns(:searched).length
+  end
+
+  test "検索で_を特別扱いしない" do
+    post :search, name: '_'
+    assert_response :success
+    assert_equal 2, assigns(:searched).length
+  end
 end
 

--- a/test/controllers/restaurants_controller_test.rb
+++ b/test/controllers/restaurants_controller_test.rb
@@ -28,5 +28,11 @@ class RestaurantsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 2, assigns(:searched).length
   end
+
+  test "\\で検索ができる" do
+    post :search, name: '\\'
+    assert_response :success
+    assert_equal 1, assigns(:searched).length
+  end
 end
 

--- a/test/fixtures/restaurants.yml
+++ b/test/fixtures/restaurants.yml
@@ -9,3 +9,8 @@ two:
   name: te_st
   num_seats: 1
   num_people: 1
+
+three:
+  name: te\st
+  num_seats: 1
+  num_people: 1

--- a/test/fixtures/restaurants.yml
+++ b/test/fixtures/restaurants.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-#one:
-#  name: MyString
-#  num_seats: 1
-#  num_people: 1
+one:
+  name: te%st_
+  num_seats: 1
+  num_people: 1
 
-#two:
-#  name: MyString
-#  num_seats: 1
-#  num_people: 1
+two:
+  name: te_st
+  num_seats: 1
+  num_people: 1


### PR DESCRIPTION
SQLのLIKE検索で特殊扱いされる文字をそのままの意味で検索できるようにしました。
PostgreSQL 9.5.3で動作確認しました。