### PR TITLE
Fix when page has external links, test will fail.

### DIFF
--- a/test/features/visit_all_page_test.rb
+++ b/test/features/visit_all_page_test.rb
@@ -12,8 +12,10 @@ feature "VisitAllPage" do
     return if visited.include? current_path
     visited << current_path
     all('a').each do |a|
-      visit a[:href]
-      visit_all_links(visited)
+      if a[:href].start_with?('/')
+        visit a[:href]
+        visit_all_links(visited)
+      end
     end
   end
 end


### PR DESCRIPTION
外部リンクは信頼性があまりない(急になくなったりするかもしれないので)ので、辿らないようにしました。