### PR TITLE
https://api.twitter.com/oauth/authenticateで[${APP_NAME}に戻る]をクリックしたときに、エラー画面ではなくトップページになるようにしました。

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,4 +12,9 @@ class SessionsController < ApplicationController
     reset_session
     redirect_to root_path
   end
+
+  def failure
+    flash[:warning] = "Twitter認証に失敗しました。"
+    redirect_to root_path
+  end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,7 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 end
+
+OmniAuth.config.on_failure = Proc.new { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   get 'auth/:provider/callback', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
+  get "/auth/failure" => "sessions#failure"
 
   get 'restaurants/slide_info'
   get 'demands/index'


### PR DESCRIPTION
ref: http://qiita.com/nekogeruge_987/items/8bd307f9ae31f27c248a