### PR TITLE
UserPointsDisplayFooter

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
           <div class="collapse navbar-collapse navbar-right nav-menu-1">
             <ul class="nav navbar-nav">
 	      <% if logged_in? %>
+              <li><%= link_to "現在のポイント:" + User.find(session[:user_id]).point.to_s, root_path %></li>
 	      <li><%= link_to session[:nickname]+"さんログアウト", logout_path %></li>
 	      <% else %>
 	      <li><%= link_to "ログイン", 'auth/twitter' %></li>

--- a/test/integration/page_trantition_test_test.rb
+++ b/test/integration/page_trantition_test_test.rb
@@ -5,8 +5,8 @@ class PageTrantitionTestTest < ActionDispatch::IntegrationTest
   test "ログインしてページを遷移したときに、ログイン情報が保持されている" do
     login
     get '/'
-    assert_select 'ul[class="nav navbar-nav"] li:nth-child(1)', 'すいているさんログアウト'
+    assert_select 'ul[class="nav navbar-nav"] li:nth-child(2)', 'すいているさんログアウト'
     get '/demands/index'
-    assert_select 'ul[class="nav navbar-nav"] li:nth-child(1)', 'すいているさんログアウト'
+    assert_select 'ul[class="nav navbar-nav"] li:nth-child(2)', 'すいているさんログアウト'
   end
 end


### PR DESCRIPTION
・ページのfooterにpoint数を表示。

アカウント名は、右上に「"アカウント名" さんログアウト」って書いてあるので、要らないかなと思いました。　
また、ポイント数は、最終的にはアカウントページのリンクになるのかなと思い、link_toで書きました（本当はただの文字にしようと思ったんですけど、linkにしないと、文字列が上にずれてしまい、見栄えが悪かったので、linkにしました^_^;）。