### PR TITLE
ページをたどるテストがpoltergeistと組み合わせた時にページを辿っていなかったのを修正しました。ついでにたどるページ数も最低限にしました。

### DIFF
--- a/test/features/visit_all_page_test.rb
+++ b/test/features/visit_all_page_test.rb
@@ -27,18 +27,25 @@ feature "VisitAllPage" do
   private
   def visit_all_links(visited)
     return if visited.include? current_path
+    visited << current_path
     assert_nothing_raised do
-      visited << current_path
-      all('a').each do |a|
-        if a && a[:href] && a[:href].start_with?('/')
-          if a[:href].include?('#')
-            return current_path
-          else
-            visit a[:href]
-            visit_all_links(visited)
-          end
+      for i in (0..(all('a').length - 1)) do
+        a = all('a')[i]
+        if visitable(a, visited)
+          visit a[:href]
+          visit_all_links(visited)
         end
       end
     end
+  end
+
+  def visitable(a, visited)
+    return false unless (a && a[:href] && a[:href].start_with?('http://127.0.0.1'))
+    return false if a[:href].include?('#')
+    path = URI.parse(a[:href]).path
+    return false if path == '/logout'
+    return false if path == '/auth/twitter'
+    return false if visited.include?(path)
+    return true
   end
 end


### PR DESCRIPTION
* Visit all page with poltergeist(with poltergiest, a[:href] starts http://).
* Visit least pages.
* Not visit /logout if logged in.
* Not visit /auth/twitter if not logged in.

ref: http://qiita.com/sanryuu/items/73ec91d977603a8138ff#%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92%E9%81%B7%E7%A7%BB%E3%81%97%E3%81%A6%E5%87%A6%E7%90%86%E3%81%99%E3%82%8B%E3%82%BF%E3%82%A4%E3%83%97

ref: #118 