### PR TITLE
些細ですが、/restaurant/indexのデザインが変更されていたのをもとに戻しました。

### DIFF
--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -23,8 +23,8 @@
           <th class="col-md-1">順位</th>
           <th class="col-md-2">店名</th>
 	  <th class="col-md-3">混雑度</th>
-	  <th class="col-md-4">最新更新時</th>
-	  <th class="col-md-5">コメント</th>
+	  <th class="col-md-2">最新更新時</th>
+	  <th class="col-md-4">コメント</th>
     	</tr>
       </thead>
       <tbody>
@@ -36,10 +36,10 @@
           <% end %>
           <tr>
             <th scope="row" class="col-md-1"><%= num %>位</th>
-            <td class="col-md-2"><%= link_to ranking.name, "https://www.google.co.jp/search?q=" + ranking.name %></td>
-	    <td class="col-md-3"><%= image_tag(@crowded_image[ranking.crowdedness], :size => "32x32") %>&nbsp;&nbsp;<%= link_to @how_crowded[ranking.crowdedness], :action => "report", :resname => ranking.id %></td>
-	    <td class="col-md-4"><%= sec2h((Time.zone.now - ranking.updated_at).to_i) %>前</td>
-            <td class="col-md-5"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;&nbsp;<%= link_to latest_comment.truncate(15), :action => "comment_log", :restaurant_id => ranking.id %></td>
+            <td class="col-md-3"><%= link_to ranking.name, "https://www.google.co.jp/search?q=" + ranking.name %></td>
+	    <td class="col-md-2"><%= image_tag(@crowded_image[ranking.crowdedness], :size => "32x32") %>&nbsp;&nbsp;<%= link_to @how_crowded[ranking.crowdedness], :action => "report", :resname => ranking.id %></td>
+	    <td class="col-md-2"><%= sec2h((Time.zone.now - ranking.updated_at).to_i) %>前</td>
+            <td class="col-md-4"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;&nbsp;<%= link_to latest_comment.truncate(15), :action => "comment_log", :restaurant_id => ranking.id %></td>
           </tr>
           <% num = num+1 %>
 	<% end %>
@@ -50,18 +50,18 @@
     <table class="table table-hover">
       <thead>
         <tr>
-          <th class="col-md-1">店名</th>
-          <th class="col-md-2">混雑度</th>
-          <th class="col-md-3">最新更新時</th>
+          <th class="col-md-3">店名</th>
+          <th class="col-md-3">混雑度</th>
+          <th class="col-md-2">最新更新時</th>
           <th class="col-md-4">登録日</th>
         </tr>
       </thead>
       <tbody>
 	  <% @new_restaurants.each do |nr| %>
         <tr>
-          <td class="col-md-1"><%= link_to nr.name, "https://www.google.co.jp/search?q=" + nr.name %></td>
-          <td class="col-md-2"><%= image_tag(@crowded_image[nr.crowdedness], :size => "32x32") %>&nbsp;&nbsp;<%= link_to @how_crowded[nr.crowdedness], :action => "report", :resname => nr.id %></td>
-          <td class="col-md-3"><%= sec2h((Time.zone.now - nr.updated_at).to_i) %>前</td>
+          <td class="col-md-3"><%= link_to nr.name, "https://www.google.co.jp/search?q=" + nr.name %></td>
+          <td class="col-md-3"><%= image_tag(@crowded_image[nr.crowdedness], :size => "32x32") %>&nbsp;&nbsp;<%= link_to @how_crowded[nr.crowdedness], :action => "report", :resname => nr.id %></td>
+          <td class="col-md-2"><%= sec2h((Time.zone.now - nr.updated_at).to_i) %>前</td>
           <td class="col-md-4"><%= nr.created_at.strftime("%Y年%m月%d日 %H時%M分") %></td>
         </tr>
       <% end %>


### PR DESCRIPTION
* bootstrap gridは画面を12分割するシステムです。
* 「今、空いている順」はcol-md-を左から順に、1,2,3,2,4にしました。
* 「新着」は左から順に、3,3,2,4にしました。