### PR TITLE
chromeの折り返しがつかない問題を解決しました。

### DIFF
--- a/app/views/demands/index.html.erb
+++ b/app/views/demands/index.html.erb
@@ -42,7 +42,7 @@
     <tr>
       <th class="col-md-1"><%= num %></th>
       <td class="col-md-3"><%= demand.demand_restaurant %></td> 
-      <td class="col-md-8"><%= demand.free %></td>
+      <td class="col-md-8" style="word-wrap:break-word;"><%= demand.free %></td>
 
       <% num = num + 1 %>
     </tr>


### PR DESCRIPTION
style="word-wrap:break-word;"をいれただけ。