### PR TITLE
コメントが一件も無い店のコメントログへのリンクを踏むと出てしまうエラーを回避。

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -11,8 +11,10 @@ class RestaurantsController < ApplicationController
   
   def index
     @restaurants = Restaurant.all
+    #@comments = Comments.all
     @new_restaurants = Restaurant.where('created_at > ?', params[:from] ? params[:from] : 30.days.ago).order(created_at: :desc)
     @per_array = Array.new
+    @crowded_image = ["garagara","yayakomi","komi","yayamachi","machi","close2","close"]
     
     #占有率が低い順に並び替える
     @rank=Restaurant.order_by_crowdedness

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -2,6 +2,7 @@
 class Restaurant < ActiveRecord::Base
   has_many :comments
   has_many :users, :through => :comments
+  has_many :favorite_restaurants
   has_many :users, :through => :favorite_restaurants
 
   has_many :opening_hours, dependent: :destroy

--- a/app/views/_restaurant_card.html.erb
+++ b/app/views/_restaurant_card.html.erb
@@ -23,13 +23,17 @@
             <%= link_to image_tag(crowded_image[restaurant.crowdedness], :size => "32x32"),
 	    { :controller => "restaurants", :action => "report", :resname => restaurant.id}, {:class => "btn"} %>
 	  </span>
-	    <% comment = restaurant.latest_comment.blank? ? "コメント無し" : restaurant.latest_comment %>
+	    <% comment = restaurant.latest_comment.nil? ? "コメント無し" : restaurant.latest_comment.blank? ? "最新コメント無し" : restaurant.latest_comment %>
 
 <!-- コメント表示部分 -->
 	    <span class="relative">
 	      <%= image_tag("balloon_hand", :alt => 'balloon', :class => "balloon") %>
 	      <span class="tenn absolute">
-		<%= link_to comment, { :controller => "restaurants", :action => "comment_log", :restaurant_id => restaurant.id }  %>
+                <% if comment == "コメント無し" %>
+                  <%= comment %>
+                <% else %>
+		  <%= link_to comment, { :controller => "restaurants", :action => "comment_log", :restaurant_id => restaurant.id }  %>
+                <% end %>
 	      </span>
 	    </span>
 

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -25,50 +25,62 @@
 
 <!-- フォローの店表示部分-->
 <% if logged_in? %>
-<div class="contents">
-  <h4>お気に入りの飲食店</h4>
-  <p align="right">[<%= link_to "フォローリスト", favorite_restaurants_path %>]</p>
+  <div class="contents">
+    <h4>お気に入りの飲食店</h4>
+    <p align="right">[<%= link_to "フォローリスト", favorite_restaurants_path %>]</p>
 
     <%= render partial: '/restaurant_card', locals: { restaurants: @my.restaurants.order("updated_at desc").limit(4), crowded_image: @crowded_image } %>
 
-</div>
+  </div>
 <% end %>
 <br>
 
-  <div class="contents">
-    <h4>今この飲食店がすいています(更新10分以内)</h4>
-    <p align="right">[<%= link_to "すべての飲食店を見る", all_rest_restaurants_path %>]</p>
-    <div class="container">
-
-      <div class="row row-eq-height">
-        <% @rank.each do |ranking| %>
-          <% if ((Time.zone.now - ranking.updated_at).to_i <= 600) %>
+<div class="contents">
+  <h4>今この飲食店がすいています(更新10分以内)</h4>
+  <p align="right">[<%= link_to "すべての飲食店を見る", all_rest_restaurants_path %>]</p>
+  <div class="container">
+    <div class="row row-eq-height">
+      <% @rank.each do |restaurant| %>
+        <% if ((Time.zone.now - restaurant.updated_at).to_i <= 600) %>
           <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
-	    <div class="thumbnail">
-	      <!-- img -->
-	      <div class="caption">
+            <div class="thumbnail">
+              <!-- img -->
+              <div class="caption">
+	        <!-- フォローボタン部分-->
+	        <div>
+                  <% if logged_in?%>
+                    <% if current_user.restaurants.include? restaurant %>
+                      <%= link_to unfollow_restaurant_path(restaurant), { method: :post, remote: true } do%>
+	              <span class="glyphicon glyphicon-star color-gold" id="now-follow-unfollow-area-<%= restaurant.id %>"></span><% end %>
+                    <% else %>
+                      <%= link_to follow_restaurant_path(restaurant), { method: :post, remote: true }  do%>
+	              <span class="glyphicon glyphicon-star-empty color-gold" id="now-follow-unfollow-area-<%= restaurant.id %>"></span><% end %>
+                    <% end %>
+                  <% end %>
+                  <span style="word-wrap:break-word;"><%= link_to restaurant.name, "https://www.google.co.jp/search?q=" + restaurant.name %></span>
+	        </div>
+                <span align="left">
+                  <%= link_to image_tag(@crowded_image[restaurant.crowdedness]+ ".png", :size => "32x32"),
+	          { :controller => "restaurants", :action => "report", :resname => restaurant.id}, {:class => "btn"} %>
+	        </span>
+	        <% comment = restaurant.latest_comment.nil? ? "コメント無し" : restaurant.latest_comment.blank? ? "最新コメント無し" : restaurant.latest_comment %>
 
-<!-- フォローボタン部分-->
-            <% if logged_in?%>
-            <% if current_user.restaurants.include? ranking %>
-            <%= link_to unfollow_restaurant_path(ranking), { method: :post, remote: true } do%><span class="glyphicon glyphicon-star color-gold" id="now-follow-unfollow-area-<%= ranking.id %>"></span><% end %>
-            <% else %>
-            <%= link_to follow_restaurant_path(ranking), { method: :post, remote: true }  do%><span class="glyphicon glyphicon-star-empty color-gold" id="now-follow-unfollow-area-<%= ranking.id %>"></span><% end %>
-            <% end %>
-            <% end %>
-
-	    <span style="word-wrap:break-word;"><%= link_to ranking.name, "https://www.google.co.jp/search?q=" + ranking.name %></span>
-
-                <p align="right">
-	          <%= link_to image_tag(@crowded_image[ranking.crowdedness], :size => "32x32"), {:action => "report", :resname => ranking.id}, {:class => "btn"} %>
-	          <%= link_to sanitize('<span class="glyphicon glyphicon-comment"></span>'), {:action => "comment_log", :restaurant_id => ranking.id}, {:class => "btn"} %>
-	        </p>
-	    
-	      </div>
-	    </div>
+                <!-- コメント表示部分 -->
+                <span class="relative">
+                  <%= image_tag("balloon_hand", :alt => 'balloon', :class => "balloon") %>
+	          <span class="tenn absolute">
+                    <% if comment == "コメント無し" %>
+                      <%= comment %>
+                    <% else %>
+                      <%= link_to comment, { :controller => "restaurants", :action => "comment_log", :restaurant_id => restaurant.id }  %>
+                    <% end %>
+		  </span>
+		</span>
+              </div>
+            </div>
           </div>
-          <% end %>
         <% end %>
-      </div>
+      <% end %>
     </div>
   </div>
+</div>


### PR DESCRIPTION
・店情報のカードに店毎の最新のコメントを載せる際、
1.コメント欄に入力は無いが、混雑度状況が知らされている。＝＞"最新コメント無し" と言うコメントログへのリンクが貼ってある。
2.コメント欄に入力がある。＝＞"最新コメント" と言うコメントログへのリンクが貼ってある。
3.一度も混雑度状況が知らされていない。＝＞"コメント無し" と書いてあるだけで、リンクは貼っていない。
以上の３つの場合分けを行いました。　
　
・トップページに表示される "今この飲食店がすいています(更新10分以内)" 欄のカードを最新の物に変更。