### PR TITLE
[WIP]Android ブラウザでカードのCSSが対応しなくなる問題を解決します。

### DIFF
--- a/app/assets/stylesheets/sticky-footer-navbar.scss
+++ b/app/assets/stylesheets/sticky-footer-navbar.scss
@@ -138,6 +138,7 @@ article {
     } 
     border-top:	1px solid $CardTopBoder;
     padding: 5px;
+    display: -webkit-flex;
     display: flex;
   }
 
@@ -167,6 +168,7 @@ article {
     }
     border-top: 1px solid $CardTopBoder;
     padding: 5px;
+    display: -webkit-flex;
     display: flex;
   }
 }


### PR DESCRIPTION
https://trello.com/c/I5HbT3Lh これです。
今、CSSに`-webkit-flex`を挿入しました。