### PR TITLE
ぐるなびクレジット変更及び、コメントが無いときのログページへのリンク削除

### DIFF
--- a/app/views/restaurants/_not_crowd.html.erb
+++ b/app/views/restaurants/_not_crowd.html.erb
@@ -106,7 +106,14 @@
             </td>
 -->
           <% else %>
-	    <td colspan="3" class="col-md-10" style="word-wrap:break-word;" bgcolor="#FFFFFF"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;&nbsp;<%= link_to last_comment.truncate(23), :action => "comment_log", :controller => "restaurants", :restaurant_id => ranking.id %>
+	    <td colspan="3" class="col-md-10" style="word-wrap:break-word;" bgcolor="#FFFFFF"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;&nbsp;
+
+<!-- 修正2017/6/22-->
+            <% if last_comment != 'コメント無し' %>
+               <%= link_to last_comment.truncate(23), :controller => "restaurants", :action => "comment_log", :restaurant_id => ranking.id %>
+            <% else %>
+                <%= last_comment %>
+            <% end %>
 
 <!--
 	    <% if (!(ranking.latest_comment.blank?) && !(session[:user_id].blank?) && (ranking.latest_comment.user_id != session[:user_id]))  %>

--- a/app/views/restaurants/shop_info.html.erb
+++ b/app/views/restaurants/shop_info.html.erb
@@ -112,4 +112,4 @@
 </div>
 
 <br>
-Powered by <a href="http://www.gnavi.co.jp/">ぐるなび</a>
+Supported by <a href="http://api.gnavi.co.jp/api/scope/" target="_blank">ぐるなびWebService</a>


### PR DESCRIPTION
ぐるなびAPI利用ルール変更に伴い、クレジットの表示を変更しました。

また、ログインしてないときにコメントが無い店へのコメントログページに飛ぶようなリンクがあったので
飛ばないようにしました。
マイページのフォロー店の最新コメントのコメントのリンクかな
